### PR TITLE
Update handlebars builtin helpers URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@
 
 Please refer to the following if you want to use conditions in your HTML template:
 
-- https://handlebarsjs.com/builtin_helpers.html
+- https://handlebarsjs.com/guide/builtin-helpers.html
 
 ### End
 


### PR DESCRIPTION
The previous link to the builtin-helpers documentation is no longer available. I'm just replacing it with the new one.