### PR TITLE
Fixed `NOTE` markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ Other logical operators are-:
     {{#ifCond inputData "||" toCheckValue}}
    ```
 
-##NOTE!!
+## NOTE!!
 You can only match 2 variables
 
 ### End


### PR DESCRIPTION
Due to the lack of a space, the markdown was not being rendered as intended.