### PR TITLE
Docs: Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,16 +127,22 @@ You can do conditional checks by calling helper block _ifCond_ example
       <meta charset="utf-8" />
       <title>Hello world!</title>
     </head>
+
     <body>
       <h1>User List</h1>
+
       <ul>
         {{#each users}}
-        <li>Name: {{this.name}}</li>
-        <li>Age: {{#ifCond this.age '===' '26'}}</li>
-        <br />
-        {{/ifCond}}
+          <li>Name: {{this.name}}</li>
+
+          {{#ifCond this.age '===' '26'}}
+            <li>Age: {{this.age}}</li>
+          {{/ifCond}}
+
+          <br />
         {{/each}}
       </ul>
+
     </body>
   </html>
   ```
@@ -169,11 +175,11 @@ Other logical operators are-:
    ```js
     {{#ifCond inputData "<=" toCheckValue}}
    ```
-- '>
+- >
    ```js
     {{#ifCond inputData ">" toCheckValue}}
    ```
-- '>=
+- >=
    ```js
     {{#ifCond inputData ">=" toCheckValue}}
    ```


### PR DESCRIPTION
- Drop not used symbols for > & >=
- Add a few lines to visually split html example